### PR TITLE
feat: Implement Replay Start endpoint

### DIFF
--- a/Record and Reply.postman_collection.json
+++ b/Record and Reply.postman_collection.json
@@ -1,0 +1,256 @@
+{
+	"info": {
+		"_postman_id": "4ec49d64-e989-48fd-b63b-aa214ec482e7",
+		"name": "Record and Reply",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "6062813"
+	},
+	"item": [
+		{
+			"name": "Ping",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:59712/api/v3/ping",
+					"host": [
+						"localhost"
+					],
+					"port": "59712",
+					"path": [
+						"api",
+						"v3",
+						"ping"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Start Recording",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"duration\" : 600000,\r\n    \"eventLimit\" : 100\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "localhost:59712/api/v3/record",
+					"host": [
+						"localhost"
+					],
+					"port": "59712",
+					"path": [
+						"api",
+						"v3",
+						"record"
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "Start Recording - empty request",
+					"originalRequest": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"duration\" : 600000,\r\n    \"eventLimit\" : 100\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "localhost:59712/api/v3/record",
+							"host": [
+								"localhost"
+							],
+							"port": "59712",
+							"path": [
+								"api",
+								"v3",
+								"record"
+							]
+						}
+					},
+					"_postman_previewlanguage": null,
+					"header": null,
+					"cookie": [],
+					"body": null
+				}
+			]
+		},
+		{
+			"name": "Recording Status",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:59712/api/v3/record",
+					"host": [
+						"localhost"
+					],
+					"port": "59712",
+					"path": [
+						"api",
+						"v3",
+						"record"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Cancel Recording",
+			"request": {
+				"method": "DELETE",
+				"header": [],
+				"url": {
+					"raw": "localhost:59712/api/v3/record",
+					"host": [
+						"localhost"
+					],
+					"port": "59712",
+					"path": [
+						"api",
+						"v3",
+						"record"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Start Replay",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"url": {
+					"raw": "localhost:59712/api/v3/replay",
+					"host": [
+						"localhost"
+					],
+					"port": "59712",
+					"path": [
+						"api",
+						"v3",
+						"replay"
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "Start Replay - empty request",
+					"originalRequest": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "localhost:59712/api/v3/replay",
+							"host": [
+								"localhost"
+							],
+							"port": "59712",
+							"path": [
+								"api",
+								"v3",
+								"replay"
+							]
+						}
+					},
+					"_postman_previewlanguage": null,
+					"header": null,
+					"cookie": [],
+					"body": null
+				}
+			]
+		},
+		{
+			"name": "Replay Status",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:59712/api/v3/replay",
+					"host": [
+						"localhost"
+					],
+					"port": "59712",
+					"path": [
+						"api",
+						"v3",
+						"replay"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Cancel Replay",
+			"request": {
+				"method": "DELETE",
+				"header": [],
+				"url": {
+					"raw": "localhost:59712/api/v3/replay",
+					"host": [
+						"localhost"
+					],
+					"port": "59712",
+					"path": [
+						"api",
+						"v3",
+						"replay"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Export Recording",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:59712/api/v3/data",
+					"host": [
+						"localhost"
+					],
+					"port": "59712",
+					"path": [
+						"api",
+						"v3",
+						"data"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Import Recording",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"url": {
+					"raw": "localhost:59712/api/v3/data",
+					"host": [
+						"localhost"
+					],
+					"port": "59712",
+					"path": [
+						"api",
+						"v3",
+						"data"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -39,8 +39,8 @@ const (
 	failedRecordDurationValidate   = "Record request failed validation: Duration must be > 0 when set"
 	failedRecordEventLimitValidate = "Record request failed validation: Event Limit must be > 0 when set"
 	failedRecording                = "Recording failed"
-	failedReplayRateValidate       = "Replay request failed validation: Replay Rate must be less than or greater than 0"
-	failedRepeatCountValidate      = "Replay request failed validation: Repeat Count must equal or greater than 0"
+	failedReplayRateValidate       = "Replay request failed validation: Replay Rate must be greater than 0"
+	failedRepeatCountValidate      = "Replay request failed validation: Repeat Count must be equal or greater than 0"
 	failedReplay                   = "Replay failed"
 )
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -39,6 +39,9 @@ const (
 	failedRecordDurationValidate   = "Record request failed validation: Duration must be > 0 when set"
 	failedRecordEventLimitValidate = "Record request failed validation: Event Limit must be > 0 when set"
 	failedRecording                = "Recording failed"
+	failedReplayRateValidate       = "Replay request failed validation: Replay Rate must be less than or greater than 0"
+	failedRepeatCountValidate      = "Replay request failed validation: Repeat Count must equal or greater than 0"
+	failedReplay                   = "Replay failed"
 )
 
 type httpController struct {
@@ -161,8 +164,33 @@ func (c *httpController) recordingStatus(writer http.ResponseWriter, request *ht
 // startReplay starts a replay session based on the values in the request
 // An error is returned if the request data is incomplete or a record or replay session is currently running.
 func (c *httpController) startReplay(writer http.ResponseWriter, request *http.Request) {
-	//TODO implement me using TDD
-	writer.WriteHeader(http.StatusNotImplemented)
+	startRequest := &dtos.ReplayRequest{}
+
+	if err := json.NewDecoder(request.Body).Decode(startRequest); err != nil {
+		writer.WriteHeader(http.StatusBadRequest)
+		_, _ = writer.Write([]byte(fmt.Sprintf("%s: %v", failedRequestJSON, err)))
+		return
+	}
+
+	if startRequest.ReplayRate == 0 {
+		writer.WriteHeader(http.StatusBadRequest)
+		_, _ = writer.Write([]byte(failedReplayRateValidate))
+		return
+	}
+
+	if startRequest.RepeatCount < 0 {
+		writer.WriteHeader(http.StatusBadRequest)
+		_, _ = writer.Write([]byte(failedRepeatCountValidate))
+		return
+	}
+
+	if err := c.dataManager.StartReplay(startRequest); err != nil {
+		writer.WriteHeader(http.StatusInternalServerError)
+		_, _ = writer.Write([]byte(fmt.Sprintf("%s: %v", failedReplay, err)))
+		return
+	}
+
+	writer.WriteHeader(http.StatusAccepted)
 }
 
 // cancelReplay cancels the current replay session

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -172,7 +172,7 @@ func (c *httpController) startReplay(writer http.ResponseWriter, request *http.R
 		return
 	}
 
-	if startRequest.ReplayRate == 0 {
+	if startRequest.ReplayRate <= 0 {
 		writer.WriteHeader(http.StatusBadRequest)
 		_, _ = writer.Write([]byte(failedReplayRateValidate))
 		return


### PR DESCRIPTION
closes #11

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **Not Yet**
  <link to docs PR>

## Testing Instructions
Run non-secure EdgeX stack
Run `make build`
Run app service with `-cp -d`
Use postman collecting to test OST to `localhost:59712/api/v3/replay`

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->