### PR TITLE
feat: implement cancel replay endpoint

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -167,8 +167,13 @@ func (c *httpController) startReplay(writer http.ResponseWriter, request *http.R
 
 // cancelReplay cancels the current replay session
 func (c *httpController) cancelReplay(writer http.ResponseWriter, request *http.Request) {
-	//TODO implement me using TDD
-	writer.WriteHeader(http.StatusNotImplemented)
+	if err := c.dataManager.CancelReplay(); err != nil {
+		writer.WriteHeader(http.StatusInternalServerError)
+		_, _ = writer.Write([]byte(fmt.Sprintf("failed to cancel replay: %v", err)))
+		return
+	}
+
+	writer.WriteHeader(http.StatusAccepted)
 }
 
 // replayStatus returns the status of the current replay session

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -250,7 +250,31 @@ func TestHttpController_ReplayStatus(t *testing.T) {
 }
 
 func TestHttpController_CancelReplay(t *testing.T) {
-	// TODO: Implement using TDD
+	target, mockDataManager, _ := createTargetAndMocks()
+
+	handler := http.HandlerFunc(target.cancelReplay)
+
+	tests := []struct {
+		Name           string
+		ExpectedStatus int
+		ExpectedError  error
+	}{
+		{"Valid", http.StatusAccepted, nil},
+		{"Error", http.StatusInternalServerError, errors.New("failed")},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			mockDataManager.On("CancelReplay").Return(test.ExpectedError).Once()
+
+			req, err := http.NewRequest(http.MethodGet, recordRoute, nil)
+			require.NoError(t, err)
+
+			testRecorder := httptest.NewRecorder()
+			handler.ServeHTTP(testRecorder, req)
+
+			require.Equal(t, test.ExpectedStatus, testRecorder.Code)
+		})
+	}
 }
 
 func TestHttpController_ExportRecordedData(t *testing.T) {


### PR DESCRIPTION
closes #9

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)*not yet*
  <link to docs PR>

## Testing Instructions
Run non-secure EdgeX stack
Run `make build`
Run app service with `-cp -d`
Use postman collecting to test DELETE to localhost:59712/api/v3/replay

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->