### PR TITLE
feat: Implement replay status endpoint

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -233,3 +233,12 @@ https://github.com/stretchr/objx/blob/master/LICENSE
 
 github.com/go-jose/go-jose/v3 (Apache-2.0) https://github.com/go-jose/go-jose
 https://github.com/go-jose/go-jose/blob/v3/LICENSE
+
+github.com/gabriel-vasile/mimetype (MIT) https://github.com/gabriel-vasile/mimetype
+https://github.com/gabriel-vasile/mimetype/blob/master/LICENSE
+
+github.com/klauspost/compress (Apache-2.0) https://github.com/klauspost/compress
+https://github.com/klauspost/compress/blob/master/LICENSE
+
+golang.org/x/exp (BSD-3) https://github.com/golang/tools
+https://github.com/golang/tools/blob/master/LICENSE

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -206,8 +206,22 @@ func (c *httpController) cancelReplay(writer http.ResponseWriter, request *http.
 
 // replayStatus returns the status of the current replay session
 func (c *httpController) replayStatus(writer http.ResponseWriter, request *http.Request) {
-	//TODO implement me using TDD
-	writer.WriteHeader(http.StatusNotImplemented)
+	replayStatus, err := c.dataManager.ReplayStatus()
+	if err != nil {
+		writer.WriteHeader(http.StatusInternalServerError)
+		_, _ = writer.Write([]byte(fmt.Sprintf("failed to retrieve replay status: %v", err)))
+		return
+	}
+
+	jsonResponse, err := json.Marshal(replayStatus)
+	if err != nil {
+		writer.WriteHeader(http.StatusInternalServerError)
+		_, _ = writer.Write([]byte(fmt.Sprintf("failed to marshal replay status: %s", err)))
+		return
+	}
+
+	writer.WriteHeader(http.StatusOK)
+	_, _ = writer.Write(jsonResponse)
 }
 
 // exportRecordedData returns the data for the last record session


### PR DESCRIPTION
closes #10

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)*not yet*
  <link to docs PR>

## Testing Instructions
Run non-secure EdgeX stack
Run make build
Run app service with -cp -d
Use postman collecting to test GET to localhost:59712/api/v3/replay

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->