### PR TITLE
feat: Implement Export Recorded Data endpoint

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -227,8 +227,22 @@ func (c *httpController) replayStatus(writer http.ResponseWriter, request *http.
 // exportRecordedData returns the data for the last record session
 // An error is returned if the no record session was run or a record session is currently running
 func (c *httpController) exportRecordedData(writer http.ResponseWriter, request *http.Request) {
-	//TODO implement me using TDD
-	writer.WriteHeader(http.StatusNotImplemented)
+	recordedData, err := c.dataManager.ExportRecordedData()
+	if err != nil {
+		writer.WriteHeader(http.StatusInternalServerError)
+		_, _ = writer.Write([]byte(fmt.Sprintf("failed to export recorded data: %v", err)))
+		return
+	}
+
+	jsonResponse, err := json.Marshal(recordedData)
+	if err != nil {
+		writer.WriteHeader(http.StatusInternalServerError)
+		_, _ = writer.Write([]byte(fmt.Sprintf("failed to marshal recorded data: %s", err)))
+		return
+	}
+
+	writer.WriteHeader(http.StatusOK)
+	_, _ = writer.Write(jsonResponse)
 }
 
 // importRecordedData imports data from a previously exported record session.


### PR DESCRIPTION
closes #7

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Run non-secure EdgeX stack
Run `make build`
Run app service with `-cp -d`
Use postman collecting to test GET to `localhost:59712/api/v3/data`

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->