### PR TITLE
feat: Implement app level Start Replay

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/edgexfoundry/app-functions-sdk-go/v3 v3.1.0-dev.15
+	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.1.0-dev.9
 	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.1.0-dev.2
 	github.com/stretchr/testify v1.8.4
 )
@@ -15,7 +16,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/diegoholiveira/jsonlogic/v3 v3.2.7 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.4.3 // indirect
-	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.1.0-dev.9 // indirect
 	github.com/edgexfoundry/go-mod-configuration/v3 v3.1.0-dev.3 // indirect
 	github.com/edgexfoundry/go-mod-messaging/v3 v3.1.0-dev.11 // indirect
 	github.com/edgexfoundry/go-mod-registry/v3 v3.1.0-dev.3 // indirect

--- a/internal/application/manager.go
+++ b/internal/application/manager.go
@@ -17,8 +17,10 @@
 package application
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -26,7 +28,11 @@ import (
 	"github.com/edgexfoundry/app-functions-sdk-go/v3/pkg/transforms"
 	"github.com/edgexfoundry/app-record-replay/internal/interfaces"
 	"github.com/edgexfoundry/app-record-replay/pkg/dtos"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/utils"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	coreDtos "github.com/edgexfoundry/go-mod-core-contracts/v3/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/requests"
+	"github.com/google/uuid"
 )
 
 const (
@@ -34,25 +40,47 @@ const (
 	setPipelineFailedMessage           = "failed to set the default function pipeline"
 	debugFilterMessage                 = "ARR Start Recording: Filter %s names %v function added to the functions pipeline"
 	debugPipelineFunctionsAddedMessage = "ARR Start Recording: CountEvents, Batch and ProcessBatchedData functions added to the functions pipeline"
+	replayExiting                      = "ARR Replay: Replay exiting due to App termination"
+	replayPublishFailed                = "failed to publish replay event: %v"
+	replayEventMarshalFailed           = "failed to marshal replay event to JSON: %v"
+	replayDeepCopyFailed               = "deep copy of event to be replayed failed: %v"
 )
 
-var recordingInProgressError = errors.New("a recording is already in progress")
+var recordingInProgressError = errors.New("a recording is in progress")
 var batchParametersNotSetError = errors.New("duration and/or count not set")
 var noRecordingRunningToCancelError = errors.New("no recording currently running")
 
+var replayInProgressError = errors.New("a replay is in progress")
+var noRecordedData = errors.New("no recorded data present")
+var invalidReplayRate = errors.New("invalid ReplayRate, value must be greater than 0")
+var invalidReplayCount = errors.New("invalid ReplayCount, value must be greater than or equal 0. Zero defaults to 1")
+
+var replayCanceled = errors.New("replay canceled")
+
 type recordedData struct {
-	Events   []coreDtos.Event
 	Duration time.Duration
+	Events   []coreDtos.Event
+	Devices  []coreDtos.Device
+	Profiles []coreDtos.DeviceProfile
 }
 
 // dataManager implements interface that records and replays captured data
 type dataManager struct {
-	dataChan           chan []coreDtos.Event
-	appSvc             appInterfaces.ApplicationService
-	eventCount         int
+	dataChan       chan []coreDtos.Event
+	appSvc         appInterfaces.ApplicationService
+	recordingMutex sync.Mutex
+
+	recordedEventCount int
 	recordingStartedAt *time.Time
 	recordedData       *recordedData
-	recordingMutex     sync.Mutex
+
+	replayStartedAt     *time.Time
+	replayedDuration    time.Duration
+	replayedEventCount  int
+	replayedRepeatCount int
+	replayError         error
+	replayContext       context.Context
+	replayCancelFunc    context.CancelFunc
 }
 
 // NewManager is the factory function which instantiates a Data Manager
@@ -65,7 +93,7 @@ func NewManager(service appInterfaces.ApplicationService) interfaces.DataManager
 
 // StartRecording starts a recording session based on the values in the request.
 // An error is returned if the request data is incomplete or a record or replay session is currently running.
-func (m *dataManager) StartRecording(request *dtos.RecordRequest) error {
+func (m *dataManager) StartRecording(request dtos.RecordRequest) error {
 	lc := m.appSvc.LoggingClient()
 
 	m.recordingMutex.Lock()
@@ -74,8 +102,13 @@ func (m *dataManager) StartRecording(request *dtos.RecordRequest) error {
 	if m.recordingStartedAt != nil {
 		return recordingInProgressError
 	}
+
+	if m.replayStartedAt != nil {
+		return replayInProgressError
+	}
+
 	m.recordedData = nil
-	m.eventCount = 0
+	m.recordedEventCount = 0
 
 	var pipeline []appInterfaces.AppFunction
 
@@ -180,7 +213,7 @@ func (m *dataManager) RecordingStatus() *dtos.RecordStatus {
 	if m.recordingStartedAt != nil {
 		status.InProgress = true
 		status.Duration = time.Since(*m.recordingStartedAt)
-		status.EventCount = m.eventCount
+		status.EventCount = m.recordedEventCount
 	} else if m.recordedData != nil {
 		status.Duration = m.recordedData.Duration
 		status.EventCount = len(m.recordedData.Events)
@@ -191,9 +224,148 @@ func (m *dataManager) RecordingStatus() *dtos.RecordStatus {
 
 // StartReplay starts a replay session based on the values in the request
 // An error is returned if the request data is incomplete or a record or replay session is currently running.
-func (m *dataManager) StartReplay(request *dtos.ReplayRequest) error {
-	//TODO implement me using TDD
-	return errors.New("not implemented")
+func (m *dataManager) StartReplay(request dtos.ReplayRequest) error {
+	m.recordingMutex.Lock()
+	defer m.recordingMutex.Unlock()
+
+	if m.recordingStartedAt != nil {
+		return recordingInProgressError
+	}
+
+	if m.replayStartedAt != nil {
+		return replayInProgressError
+	}
+
+	if m.recordedData == nil {
+		return noRecordedData
+	}
+
+	if request.ReplayRate <= 0 {
+		return invalidReplayRate
+	}
+
+	if request.RepeatCount < 0 {
+		return invalidReplayCount
+	}
+
+	now := time.Now()
+	m.replayStartedAt = &now
+	m.replayedDuration = 0
+	m.replayedEventCount = 0
+	m.replayedRepeatCount = 0
+	m.replayError = nil
+	m.replayContext, m.replayCancelFunc = context.WithCancel(context.Background())
+
+	go m.replayRecordedEvents(request)
+
+	return nil
+}
+
+func (m *dataManager) replayRecordedEvents(request dtos.ReplayRequest) {
+	var previousEventTime int64
+	firstEvent := true
+	lc := m.appSvc.LoggingClient()
+
+	// Replay Count of zero defaults to 1.
+	replayCount := 1
+	if request.RepeatCount > 0 {
+		replayCount = request.RepeatCount
+	}
+
+	lc.Debugf("ARR Replay: Replay starting with Replay Rate of %v and Repeat Count of %d ", request.ReplayRate, replayCount)
+
+	for i := 0; i < replayCount; i++ {
+		for _, event := range m.recordedData.Events {
+			// Check if service is terminating
+			if m.appSvc.AppContext().Err() != nil {
+				m.recordingMutex.Lock()
+				m.replayStartedAt = nil
+				m.recordingMutex.Unlock()
+				m.appSvc.LoggingClient().Info(replayExiting)
+				return
+			}
+
+			// Check if replay cancel func has been called to cancel the replay
+			if m.replayContext.Err() != nil {
+				m.setReplayError(replayCanceled)
+				return
+			}
+
+			replayEvent := coreDtos.Event{}
+			if err := utils.DeepCopy(event, &replayEvent); err != nil {
+				m.setReplayError(fmt.Errorf(replayDeepCopyFailed, err))
+				return
+			}
+
+			// Send the first event immediately and then wait appropriate time between events
+			if firstEvent {
+				firstEvent = false
+			} else {
+				delay := replayEvent.Origin - previousEventTime
+
+				// Replay Rate less than one increases the delay to slow down replay pace while greater than one
+				// decreases the delay to increase the replay pace.
+				delay = int64(float32(delay) * (1 / request.ReplayRate))
+
+				// Best we can do with realtime capabilities
+				time.Sleep(time.Duration(delay))
+			}
+
+			previousEventTime = replayEvent.Origin
+
+			topic := common.BuildTopic(strings.Replace(common.CoreDataEventSubscribeTopic, "/#", "", 1),
+				replayEvent.ProfileName, replayEvent.DeviceName, replayEvent.SourceName)
+
+			newOrigin := time.Now().UnixNano()
+			replayEvent.Origin = newOrigin
+			replayEvent.Id = uuid.NewString()
+			for index := range replayEvent.Readings {
+				replayEvent.Readings[index].Origin = newOrigin
+				replayEvent.Readings[index].Id = uuid.NewString()
+			}
+
+			addEvent := requests.NewAddEventRequest(replayEvent)
+
+			if err := m.appSvc.PublishWithTopic(topic, addEvent, common.ContentTypeJSON); err != nil {
+				m.setReplayError(fmt.Errorf(replayPublishFailed, err))
+				return
+			}
+
+			lc.Debugf("ARR Replay: Replayed Event to topic: %s", topic)
+
+			m.incrementReplayedEventCount()
+		}
+
+		m.incrementReplayRepeatCount()
+	}
+
+	m.recordingMutex.Lock()
+	defer m.recordingMutex.Unlock()
+	m.replayedDuration = time.Since(*m.replayStartedAt)
+	m.replayStartedAt = nil
+
+	lc.Debugf("ARR Replay: Replay completed in %s. %d events replayed with %d repeated replays",
+		m.replayedDuration.String(), m.replayedEventCount, m.replayedRepeatCount)
+}
+
+func (m *dataManager) setReplayError(err error) {
+	m.recordingMutex.Lock()
+	defer m.recordingMutex.Unlock()
+	m.replayError = err
+	m.replayStartedAt = nil
+	m.appSvc.LoggingClient().Errorf("ARR Replay: Replay stopped due to error: %v", err)
+}
+
+func (m *dataManager) incrementReplayedEventCount() {
+	m.recordingMutex.Lock()
+	defer m.recordingMutex.Unlock()
+	m.replayedEventCount++
+}
+
+func (m *dataManager) incrementReplayRepeatCount() {
+	m.recordingMutex.Lock()
+	defer m.recordingMutex.Unlock()
+	m.replayedRepeatCount++
 }
 
 // CancelReplay cancels the current replay session
@@ -241,9 +413,9 @@ func (m *dataManager) countEvents(_ appInterfaces.AppFunctionContext, data any) 
 	m.recordingMutex.Lock()
 	defer m.recordingMutex.Unlock()
 
-	m.eventCount++
+	m.recordedEventCount++
 
-	m.appSvc.LoggingClient().Debugf("ARR Event Count: received event to be recorded. Current event count is %d", m.eventCount)
+	m.appSvc.LoggingClient().Debugf("ARR Event Count: received event to be recorded. Current event count is %d", m.recordedEventCount)
 
 	return true, data
 }

--- a/internal/application/manager_test.go
+++ b/internal/application/manager_test.go
@@ -16,18 +16,42 @@
 package application
 
 import (
+	"context"
 	"errors"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/edgexfoundry/app-functions-sdk-go/v3/pkg/interfaces/mocks"
 	"github.com/edgexfoundry/app-record-replay/pkg/dtos"
 	loggerMocks "github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger/mocks"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	coreDtos "github.com/edgexfoundry/go-mod-core-contracts/v3/dtos"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+const (
+	expectedProfileName = "testProfile"
+	expectedDeviceName  = "testDevice"
+	expectedSourceName  = "testSource"
+)
+
+var expectedEventData = []coreDtos.Event{
+	coreDtos.NewEvent(expectedProfileName, expectedDeviceName, expectedSourceName),
+	coreDtos.NewEvent(expectedProfileName, expectedDeviceName, expectedSourceName),
+	coreDtos.NewEvent(expectedProfileName, expectedDeviceName, expectedSourceName),
+}
+
+func TestMain(m *testing.M) {
+	for i := range expectedEventData {
+		_ = expectedEventData[i].AddSimpleReading(expectedSourceName, common.ValueTypeString, "test1")
+	}
+
+	os.Exit(m.Run())
+}
 
 func TestNewManager(t *testing.T) {
 	target := NewManager(&mocks.ApplicationService{})
@@ -37,16 +61,17 @@ func TestNewManager(t *testing.T) {
 	assert.NotNil(t, d.dataChan)
 }
 
-func TestDefaultDataManager_StartRecording(t *testing.T) {
-	countAndTimeNoFiltersRequest := &dtos.RecordRequest{
+func TestDataManager_StartRecording(t *testing.T) {
+	countAndTimeNoFiltersRequest := dtos.RecordRequest{
 		Duration:   10 * time.Second,
 		EventLimit: 100,
 	}
 
 	tests := []struct {
 		Name                    string
-		StartRequest            *dtos.RecordRequest
+		StartRequest            dtos.RecordRequest
 		RecordingAlreadyRunning bool
+		ReplayRunning           bool
 		ExpectedStartError      error
 		SetPipelineError        error
 	}{
@@ -56,7 +81,7 @@ func TestDefaultDataManager_StartRecording(t *testing.T) {
 		},
 		{
 			Name: "Happy Path - By Count - 3 include filters",
-			StartRequest: &dtos.RecordRequest{
+			StartRequest: dtos.RecordRequest{
 				EventLimit:            100,
 				IncludeDeviceProfiles: []string{"test-profile1", "test-profile2"},
 				IncludeDevices:        []string{"test-device1", "test-device2"},
@@ -65,7 +90,7 @@ func TestDefaultDataManager_StartRecording(t *testing.T) {
 		},
 		{
 			Name: "Happy Path - By Duration - 3 exclude filters",
-			StartRequest: &dtos.RecordRequest{
+			StartRequest: dtos.RecordRequest{
 				Duration:              10 * time.Second,
 				ExcludeDeviceProfiles: []string{"test-profile3", "test-profile4"},
 				ExcludeDevices:        []string{"test-device3", "test-device4"},
@@ -79,13 +104,19 @@ func TestDefaultDataManager_StartRecording(t *testing.T) {
 			ExpectedStartError:      recordingInProgressError,
 		},
 		{
+			Name:               "Fail Path - replay is running",
+			StartRequest:       countAndTimeNoFiltersRequest,
+			ReplayRunning:      true,
+			ExpectedStartError: replayInProgressError,
+		},
+		{
 			Name:             "Fail Path - pipeline set error",
 			StartRequest:     countAndTimeNoFiltersRequest,
 			SetPipelineError: errors.New("failed"),
 		},
 		{
 			Name:               "Fail Path - No count or duration set",
-			StartRequest:       &dtos.RecordRequest{},
+			StartRequest:       dtos.RecordRequest{},
 			ExpectedStartError: batchParametersNotSetError,
 		},
 	}
@@ -147,9 +178,13 @@ func TestDefaultDataManager_StartRecording(t *testing.T) {
 				target.recordingStartedAt = &now
 			}
 
+			if test.ReplayRunning {
+				target.replayStartedAt = &now
+			}
+
 			// simulate previous recorded data is present
 			target.recordedData = &recordedData{}
-			target.eventCount = 100
+			target.recordedEventCount = 100
 
 			startErr := target.StartRecording(test.StartRequest)
 
@@ -167,7 +202,7 @@ func TestDefaultDataManager_StartRecording(t *testing.T) {
 
 			require.NoError(t, startErr)
 			assert.Nil(t, target.recordedData)
-			assert.Zero(t, target.eventCount)
+			assert.Zero(t, target.recordedEventCount)
 			assert.NotNil(t, target.recordingStartedAt)
 
 			mockSdk.AssertExpectations(t)
@@ -201,7 +236,7 @@ func TestDefaultDataManager_StartRecording(t *testing.T) {
 	}
 }
 
-func TestDefaultDataManager_RecordingStatus(t *testing.T) {
+func TestDataManager_RecordingStatus(t *testing.T) {
 	tests := []struct {
 		Name           string
 		ExpectedStatus *dtos.RecordStatus
@@ -240,7 +275,7 @@ func TestDefaultDataManager_RecordingStatus(t *testing.T) {
 				// Set up case when recording is in progress
 				startTime := time.Now().Add(test.ExpectedStatus.Duration * -1)
 				target.recordingStartedAt = &startTime
-				target.eventCount = test.ExpectedStatus.EventCount
+				target.recordedEventCount = test.ExpectedStatus.EventCount
 			} else if test.ExpectedStatus.EventCount > 0 || test.ExpectedStatus.Duration > 0 {
 				// Set up case when recording is finished and using recorded data
 				target.recordedData = &recordedData{
@@ -264,7 +299,7 @@ func TestDefaultDataManager_RecordingStatus(t *testing.T) {
 	}
 }
 
-func TestDefaultDataManager_CancelRecording(t *testing.T) {
+func TestDataManager_CancelRecording(t *testing.T) {
 	tests := []struct {
 		Name             string
 		RecordingRunning bool
@@ -310,27 +345,260 @@ func TestDefaultDataManager_CancelRecording(t *testing.T) {
 	}
 }
 
-func TestDefaultDataManager_StartReplay(t *testing.T) {
+func TestDataManager_StartReplay(t *testing.T) {
+	expectedTopic := common.BuildTopic(strings.Replace(common.CoreDataEventSubscribeTopic, "/#", "", 1),
+		expectedProfileName, expectedDeviceName, expectedSourceName)
+	goodRequest := dtos.ReplayRequest{
+		ReplayRate:  1,
+		RepeatCount: 2,
+	}
+
+	tests := []struct {
+		Name                 string
+		StartRequest         dtos.ReplayRequest
+		RecordingRunning     bool
+		ReplayAlreadyRunning bool
+		RecordedData         *recordedData
+		PublishError         error
+		ExpectedStartError   error
+	}{
+		{
+			Name:         "Happy Path - Recorded Data w/o dependent data",
+			StartRequest: goodRequest,
+			RecordedData: &recordedData{
+				Events: expectedEventData,
+			},
+		},
+		{
+			Name:         "Error Path - failed to publish",
+			StartRequest: goodRequest,
+			RecordedData: &recordedData{
+				Events: expectedEventData,
+			},
+			PublishError: errors.New("publish failed"),
+		},
+		{
+			Name: "Error Path - Bad ReplayRate -1",
+			StartRequest: dtos.ReplayRequest{
+				ReplayRate:  -1,
+				RepeatCount: 0,
+			},
+			RecordedData:       &recordedData{},
+			ExpectedStartError: invalidReplayRate,
+		},
+		{
+			Name: "Error Path - Bad ReplayRate 0",
+			StartRequest: dtos.ReplayRequest{
+				ReplayRate:  0,
+				RepeatCount: 0,
+			},
+			RecordedData:       &recordedData{},
+			ExpectedStartError: invalidReplayRate,
+		},
+		{
+			Name: "Error Path - Bad RepeatCount -1",
+			StartRequest: dtos.ReplayRequest{
+				ReplayRate:  1,
+				RepeatCount: -1,
+			},
+			RecordedData:       &recordedData{},
+			ExpectedStartError: invalidReplayCount,
+		},
+		{
+			Name:               "Error Path - Recording in progress",
+			RecordingRunning:   true,
+			ExpectedStartError: recordingInProgressError,
+		},
+		{
+			Name:                 "Error Path - Replay in progress",
+			ReplayAlreadyRunning: true,
+			ExpectedStartError:   replayInProgressError,
+		},
+		{
+			Name:               "Error Path - No recorded data",
+			ExpectedStartError: noRecordedData,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			mockLogger := &loggerMocks.LoggingClient{}
+			mockLogger.On("Debugf", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			mockLogger.On("Errorf", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+
+			mockSdk := &mocks.ApplicationService{}
+			mockSdk.On("LoggingClient").Return(mockLogger)
+			mockSdk.On("AppContext").Return(context.Background())
+			mockSdk.On("PublishWithTopic", expectedTopic, mock.Anything, common.ContentTypeJSON).Return(test.PublishError)
+			target := NewManager(mockSdk).(*dataManager)
+
+			target.recordingStartedAt = nil
+			target.replayStartedAt = nil
+			if test.RecordedData != nil {
+				target.recordedData = test.RecordedData
+			}
+
+			now := time.Now()
+
+			if test.RecordingRunning {
+				target.recordingStartedAt = &now
+			}
+
+			if test.ReplayAlreadyRunning {
+				target.replayStartedAt = &now
+			}
+
+			if test.RecordedData != nil {
+				target.recordedData = test.RecordedData
+			}
+
+			err := target.StartReplay(test.StartRequest)
+
+			if test.ExpectedStartError != nil {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, test.ExpectedStartError.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			target.recordingMutex.Lock()
+			assert.NotNil(t, target.replayStartedAt)
+			assert.Zero(t, target.replayedDuration)
+			assert.Zero(t, target.replayedEventCount)
+			target.recordingMutex.Unlock()
+
+			// Wait for the replay to complete
+			for {
+				target.recordingMutex.Lock()
+				replayStartedAt := target.replayStartedAt
+				target.recordingMutex.Unlock()
+
+				if replayStartedAt == nil {
+					break
+				}
+
+				time.Sleep(500 * time.Millisecond)
+			}
+
+			target.recordingMutex.Lock()
+			defer target.recordingMutex.Unlock()
+
+			if test.PublishError != nil {
+				require.Error(t, target.replayError)
+				assert.ErrorContains(t, target.replayError, test.PublishError.Error())
+				return
+			}
+
+			expectedEventCount := len(test.RecordedData.Events) * test.StartRequest.RepeatCount
+			assert.Equal(t, expectedEventCount, target.replayedEventCount)
+			assert.NotZero(t, target.replayedDuration)
+		})
+	}
+}
+
+func TestDataManager_StartReplay_Cancel(t *testing.T) {
+	// These values should allow time to cancel.
+	replayRequest := dtos.ReplayRequest{
+		ReplayRate:  0.10,
+		RepeatCount: 100,
+	}
+
+	tests := []struct {
+		Name                string
+		ReplayCancel        bool
+		AppTerminated       bool
+		ExpectedReplayError error
+	}{
+		{
+			Name:                "Replay cancel",
+			ReplayCancel:        true,
+			ExpectedReplayError: errors.New("replay canceled"),
+		},
+		{
+			Name:                "App cancel",
+			AppTerminated:       true,
+			ExpectedReplayError: errors.New("app terminated"),
+		},
+	}
+
+	appCtx, appCancelFunc := context.WithCancel(context.Background())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			mockLogger := &loggerMocks.LoggingClient{}
+			mockLogger.On("Info", replayExiting)
+			mockLogger.On("Debugf", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			mockLogger.On("Errorf", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+
+			mockSdk := &mocks.ApplicationService{}
+			mockSdk.On("LoggingClient").Return(mockLogger)
+			mockSdk.On("AppContext").Return(appCtx)
+			mockSdk.On("PublishWithTopic", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+			target := NewManager(mockSdk).(*dataManager)
+
+			target.recordedData = &recordedData{
+				Events: expectedEventData,
+			}
+
+			err := target.StartReplay(replayRequest)
+			require.NoError(t, err)
+
+			require.True(t, test.AppTerminated || test.ReplayCancel)
+
+			if test.AppTerminated {
+				appCancelFunc()
+			} else if test.ReplayCancel {
+				target.replayCancelFunc()
+			}
+
+			// Wait for the replay to cancel
+			for {
+				target.recordingMutex.Lock()
+				replayStartedAt := target.replayStartedAt
+				target.recordingMutex.Unlock()
+
+				if replayStartedAt == nil {
+					break
+				}
+
+				time.Sleep(500 * time.Millisecond)
+			}
+
+			if test.AppTerminated {
+				mockLogger.AssertCalled(t, "Info", replayExiting)
+				return
+			}
+
+			target.recordingMutex.Lock()
+			defer target.recordingMutex.Unlock()
+
+			require.Error(t, target.replayError)
+			assert.Equal(t, test.ExpectedReplayError, target.replayError)
+
+		})
+	}
+
+	// This is need to appease the linter.
+	appCancelFunc()
+}
+
+func TestDataManager_ReplayStatus(t *testing.T) {
 	// TODO: Implement using TDD
 }
 
-func TestDefaultDataManager_ReplayStatus(t *testing.T) {
+func TestDataManager_CancelReplay(t *testing.T) {
 	// TODO: Implement using TDD
 }
 
-func TestDefaultDataManager_CancelReplay(t *testing.T) {
+func TestDataManager_ExportRecordedData(t *testing.T) {
 	// TODO: Implement using TDD
 }
 
-func TestDefaultDataManager_ExportRecordedData(t *testing.T) {
+func TestDataManager_ImportRecordedData(t *testing.T) {
 	// TODO: Implement using TDD
 }
 
-func TestDefaultDataManager_ImportRecordedData(t *testing.T) {
-	// TODO: Implement using TDD
-}
-
-func TestDefaultDataManager_CountEvents(t *testing.T) {
+func TestDataManager_CountEvents(t *testing.T) {
 	tests := []struct {
 		Name          string
 		Data          any
@@ -361,12 +629,12 @@ func TestDefaultDataManager_CountEvents(t *testing.T) {
 				require.Equal(t, test.Data, actual)
 			}
 
-			assert.Equal(t, test.ExpectedCount, target.eventCount)
+			assert.Equal(t, test.ExpectedCount, target.recordedEventCount)
 		})
 	}
 }
 
-func TestDefaultDataManager_ProcessBatchedData(t *testing.T) {
+func TestDataManager_ProcessBatchedData(t *testing.T) {
 	expectedBatchedEvents := []coreDtos.Event{
 		coreDtos.NewEvent("test-profile1", "test-device1", "test-source1"),
 		coreDtos.NewEvent("test-profile2", "test-device2", "test-source2"),

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -129,7 +129,7 @@ func (c *httpController) startRecording(writer http.ResponseWriter, request *htt
 		return
 	}
 
-	if err := c.dataManager.StartRecording(startRequest); err != nil {
+	if err := c.dataManager.StartRecording(*startRequest); err != nil {
 		writer.WriteHeader(http.StatusInternalServerError)
 		_, _ = writer.Write([]byte(fmt.Sprintf("%s: %v", failedRecording, err)))
 		return
@@ -187,7 +187,7 @@ func (c *httpController) startReplay(writer http.ResponseWriter, request *http.R
 		return
 	}
 
-	if err := c.dataManager.StartReplay(startRequest); err != nil {
+	if err := c.dataManager.StartReplay(*startRequest); err != nil {
 		writer.WriteHeader(http.StatusInternalServerError)
 		_, _ = writer.Write([]byte(fmt.Sprintf("%s: %v", failedReplay, err)))
 		return

--- a/internal/interfaces/manager.go
+++ b/internal/interfaces/manager.go
@@ -21,14 +21,14 @@ import "github.com/edgexfoundry/app-record-replay/pkg/dtos"
 type DataManager interface {
 	// StartRecording starts a recording session based on the values in the request.
 	// An error is returned if the request data is incomplete or a record or replay session is currently running.
-	StartRecording(request *dtos.RecordRequest) error
+	StartRecording(request dtos.RecordRequest) error
 	// CancelRecording cancels the current recording session
 	CancelRecording() error
 	// RecordingStatus returns the status of the current recording session
 	RecordingStatus() *dtos.RecordStatus
 	// StartReplay starts a replay session based on the values in the request
 	// An error is returned if the request data is incomplete or a record or replay session is currently running.
-	StartReplay(request *dtos.ReplayRequest) error
+	StartReplay(request dtos.ReplayRequest) error
 	// CancelReplay cancels the current replay session
 	CancelReplay() error
 	// ReplayStatus returns the status of the current replay session

--- a/internal/interfaces/mocks/DataManager.go
+++ b/internal/interfaces/mocks/DataManager.go
@@ -124,11 +124,11 @@ func (_m *DataManager) ReplayStatus() (*dtos.ReplayStatus, error) {
 }
 
 // StartRecording provides a mock function with given fields: request
-func (_m *DataManager) StartRecording(request *dtos.RecordRequest) error {
+func (_m *DataManager) StartRecording(request dtos.RecordRequest) error {
 	ret := _m.Called(request)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*dtos.RecordRequest) error); ok {
+	if rf, ok := ret.Get(0).(func(dtos.RecordRequest) error); ok {
 		r0 = rf(request)
 	} else {
 		r0 = ret.Error(0)
@@ -138,11 +138,11 @@ func (_m *DataManager) StartRecording(request *dtos.RecordRequest) error {
 }
 
 // StartReplay provides a mock function with given fields: request
-func (_m *DataManager) StartReplay(request *dtos.ReplayRequest) error {
+func (_m *DataManager) StartReplay(request dtos.ReplayRequest) error {
 	ret := _m.Called(request)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*dtos.ReplayRequest) error); ok {
+	if rf, ok := ret.Get(0).(func(dtos.ReplayRequest) error); ok {
 		r0 = rf(request)
 	} else {
 		r0 = ret.Error(0)

--- a/res/configuration.yaml
+++ b/res/configuration.yaml
@@ -28,3 +28,6 @@ MessageBus:
     ClientId: "app-record-replay"
 
 # Using default Trigger config from common config
+
+ApplicationSettings:
+  MaxReplayDelay: "45s"


### PR DESCRIPTION
closes #12

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **Not Yet**
  <link to docs PR>

## Testing Instructions
Run `make run no-secty ds-virtual` from compose builder
Build app service
run `WRITABLE_LOGLEVEL=DEBUG ./app-record-replay -cp -d | grep "ARR "` to run app service 
POST the following to `localhost:59712/api/v3/record`
```
{
    "duration" : 60000000000,
    "eventLimit" : 10
}
```
Verify `202` response code
Verify logs contains the following messages
```
ARR Start Recording: Recording of Events has started with EventLimit=10 and Duration=1m0s
ARR Process Recorded Data: 10 events in 1.259655215s have been saved for replay
```
Stop the Device Virtual container so it isn't creating any new events
Send DELETE to `http://localhost:59880/api/v3/event/age/10` to remove all events in core data 
Send GET to `http://localhost:59880/api/v3/event/all` to verify all events have been removed
Send POST the following to `localhost:59712/api/v3/replay`
```
{
    "replayRate" : 2,
    "repeatCount" : 2
}
```
Verify 202 response code
Verify logs contains the following messages
```
ARR Replay: Replay starting with Replay Rate of 2 and Repeat Count of 2 
ARR Replay: Replayed Event to topic: events/device/Random-Boolean-Device/Random-Boolean-Device/Bool
ARR Replay: Replay completed in 17.1619ms. 20 events replayed with 2 repeated replays
```
Send GET to `http://localhost:59880/api/v3/event/all` 
Verify summary in response is:
```
{
    "apiVersion": "v3",
    "statusCode": 200,
    "totalCount": 20,
    "events": [
        ...
   ]
}
```


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->