### PR TITLE
feat: Add app level Replay Status

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -209,12 +209,7 @@ func (c *httpController) cancelReplay(writer http.ResponseWriter, request *http.
 
 // replayStatus returns the status of the current replay session
 func (c *httpController) replayStatus(writer http.ResponseWriter, request *http.Request) {
-	replayStatus, err := c.dataManager.ReplayStatus()
-	if err != nil {
-		writer.WriteHeader(http.StatusInternalServerError)
-		_, _ = writer.Write([]byte(fmt.Sprintf("failed to retrieve replay status: %v", err)))
-		return
-	}
+	replayStatus := c.dataManager.ReplayStatus()
 
 	jsonResponse, err := json.Marshal(replayStatus)
 	if err != nil {

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -174,13 +174,13 @@ func TestHttpController_RecordingStatus(t *testing.T) {
 	}
 	tests := []struct {
 		Name             string
-		ExpectedResponse *dtos.RecordStatus
+		ExpectedResponse dtos.RecordStatus
 		ExpectedStatus   int
 		ExpectedError    error
 	}{
 		{
 			Name:             "Valid in progress status test",
-			ExpectedResponse: &inProgressRecordStatus,
+			ExpectedResponse: inProgressRecordStatus,
 			ExpectedStatus:   http.StatusOK,
 			ExpectedError:    nil,
 		},
@@ -205,7 +205,7 @@ func TestHttpController_RecordingStatus(t *testing.T) {
 			err = json.Unmarshal(testRecorder.Body.Bytes(), &actualResponse)
 			require.NoError(t, err)
 
-			require.Equal(t, test.ExpectedResponse, &actualResponse)
+			require.Equal(t, test.ExpectedResponse, actualResponse)
 		})
 	}
 }
@@ -311,26 +311,21 @@ func TestHttpController_ReplayStatus(t *testing.T) {
 	}
 	tests := []struct {
 		Name             string
-		ExpectedResponse *dtos.ReplayStatus
+		ExpectedResponse dtos.ReplayStatus
 		ExpectedStatus   int
 		ExpectedError    error
 	}{
 		{
 			Name:             "Valid in progress status test",
-			ExpectedResponse: &inProgressReplayStatus,
+			ExpectedResponse: inProgressReplayStatus,
 			ExpectedStatus:   http.StatusOK,
 			ExpectedError:    nil,
 		},
 		{
 			Name:             "Valid not running replay status",
-			ExpectedResponse: &notRunningReplayStatus,
+			ExpectedResponse: notRunningReplayStatus,
 			ExpectedStatus:   http.StatusOK,
 			ExpectedError:    nil,
-		},
-		{
-			Name:           "retrieve status error",
-			ExpectedError:  errors.New("failed"),
-			ExpectedStatus: http.StatusInternalServerError,
 		},
 	}
 
@@ -353,7 +348,7 @@ func TestHttpController_ReplayStatus(t *testing.T) {
 			err = json.Unmarshal(testRecorder.Body.Bytes(), &actualResponse)
 			require.NoError(t, err)
 
-			require.Equal(t, test.ExpectedResponse, &actualResponse)
+			require.Equal(t, test.ExpectedResponse, actualResponse)
 		})
 	}
 }

--- a/internal/interfaces/manager.go
+++ b/internal/interfaces/manager.go
@@ -25,14 +25,14 @@ type DataManager interface {
 	// CancelRecording cancels the current recording session
 	CancelRecording() error
 	// RecordingStatus returns the status of the current recording session
-	RecordingStatus() *dtos.RecordStatus
+	RecordingStatus() dtos.RecordStatus
 	// StartReplay starts a replay session based on the values in the request
 	// An error is returned if the request data is incomplete or a record or replay session is currently running.
 	StartReplay(request dtos.ReplayRequest) error
 	// CancelReplay cancels the current replay session
 	CancelReplay() error
 	// ReplayStatus returns the status of the current replay session
-	ReplayStatus() (*dtos.ReplayStatus, error)
+	ReplayStatus() dtos.ReplayStatus
 	// ExportRecordedData returns the data for the last record session
 	// An error is returned if the no record session was run or a record session is currently running
 	ExportRecordedData() (*dtos.RecordedData, error)

--- a/internal/interfaces/mocks/DataManager.go
+++ b/internal/interfaces/mocks/DataManager.go
@@ -82,45 +82,31 @@ func (_m *DataManager) ImportRecordedData(data *dtos.RecordedData) error {
 }
 
 // RecordingStatus provides a mock function with given fields:
-func (_m *DataManager) RecordingStatus() *dtos.RecordStatus {
+func (_m *DataManager) RecordingStatus() dtos.RecordStatus {
 	ret := _m.Called()
 
-	var r0 *dtos.RecordStatus
-	if rf, ok := ret.Get(0).(func() *dtos.RecordStatus); ok {
+	var r0 dtos.RecordStatus
+	if rf, ok := ret.Get(0).(func() dtos.RecordStatus); ok {
 		r0 = rf()
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*dtos.RecordStatus)
-		}
+		r0 = ret.Get(0).(dtos.RecordStatus)
 	}
 
 	return r0
 }
 
 // ReplayStatus provides a mock function with given fields:
-func (_m *DataManager) ReplayStatus() (*dtos.ReplayStatus, error) {
+func (_m *DataManager) ReplayStatus() dtos.ReplayStatus {
 	ret := _m.Called()
 
-	var r0 *dtos.ReplayStatus
-	var r1 error
-	if rf, ok := ret.Get(0).(func() (*dtos.ReplayStatus, error)); ok {
-		return rf()
-	}
-	if rf, ok := ret.Get(0).(func() *dtos.ReplayStatus); ok {
+	var r0 dtos.ReplayStatus
+	if rf, ok := ret.Get(0).(func() dtos.ReplayStatus); ok {
 		r0 = rf()
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*dtos.ReplayStatus)
-		}
+		r0 = ret.Get(0).(dtos.ReplayStatus)
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // StartRecording provides a mock function with given fields: request

--- a/pkg/dtos/replay.go
+++ b/pkg/dtos/replay.go
@@ -39,4 +39,6 @@ type ReplayStatus struct {
 	Duration time.Duration `json:"duration"`
 	// RepeatCount is the number of times the replay of the recorded data has been completed.
 	RepeatCount int `json:"repeatCount"`
+	// ErrorMessage contains the error message if an error occurred during replay
+	ErrorMessage string
 }


### PR DESCRIPTION
closes #30

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **Not Yet**
  <link to docs PR>

## Testing Instructions
Run `make run no-secty ds-virtual` from compose builder
Build app service
run `WRITABLE_LOGLEVEL=DEBUG ./app-record-replay -cp -d -o | grep "ARR "` to run app service 
Send GET to `localhost:59712/api/v3/replay`
Verify response code is 200 and body is
```
{"running":false,"eventCount":0,"duration":0,"repeatCount":0,"ErrorMessage":"no replay running or has previously been run"}
```
Send POST the following to `localhost:59712/api/v3/record` to record data
{
    "duration" : 60000000000,
    "eventLimit" : 10
}
Once logs show :
```
ARR Process Recorded Data: 10 events in 19.933246786s have been saved for replay
```
Send POST to `localhost:59712/api/v3/replay` with the following
```
{
    "replayRate" : 1,
    "repeatCount" : 5
}
```
Then send GET to  `localhost:59712/api/v3/replay` 
Verify response code is 200 and body is something like
```
{"running":true,"eventCount":36,"duration":72100745035,"repeatCount":3,"ErrorMessage":""}
```
Repeat this until response is:
```
{"running":false,"eventCount":50,"duration":99692924626,"repeatCount":5,"ErrorMessage":""}
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->