### PR TITLE
feat: Implement Upload (Import) Endpoint

### DIFF
--- a/internal/application/manager.go
+++ b/internal/application/manager.go
@@ -416,6 +416,7 @@ func (m *dataManager) ExportRecordedData() (*dtos.RecordedData, error) {
 }
 
 // ImportRecordedData imports data from a previously exported record session.
+// If overwrite parameter is true then Device Profiles and/or Devices will be overwritten.
 // An error is returned if a record or replay session is currently running or the data is incomplete
 func (m *dataManager) ImportRecordedData(data *dtos.RecordedData, overwrite bool) error {
 	//TODO implement me using TDD

--- a/internal/application/manager.go
+++ b/internal/application/manager.go
@@ -417,7 +417,7 @@ func (m *dataManager) ExportRecordedData() (*dtos.RecordedData, error) {
 
 // ImportRecordedData imports data from a previously exported record session.
 // An error is returned if a record or replay session is currently running or the data is incomplete
-func (m *dataManager) ImportRecordedData(data *dtos.RecordedData) error {
+func (m *dataManager) ImportRecordedData(data *dtos.RecordedData, overwrite bool) error {
 	//TODO implement me using TDD
 	return errors.New("not implemented")
 }

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -289,19 +289,6 @@ func (c *httpController) exportRecordedData(writer http.ResponseWriter, request 
 // importRecordedData imports data from a previously exported record session.
 // An error is returned if a record or replay session is currently running or the data is incomplete
 func (c *httpController) importRecordedData(writer http.ResponseWriter, request *http.Request) {
-	recordDataRequest := &dtos.RecordedData{}
-
-	if err := json.NewDecoder(request.Body).Decode(recordDataRequest); err != nil {
-		writer.WriteHeader(http.StatusBadRequest)
-		_, _ = writer.Write([]byte(fmt.Sprintf("%s: %v", failedRequestJSON, err)))
-		return
-	}
-
-	if err := c.dataManager.ImportRecordedData(recordDataRequest); err != nil {
-		writer.WriteHeader(http.StatusInternalServerError)
-		_, _ = writer.Write([]byte(fmt.Sprintf("%s: %v", failedImportingData, err)))
-		return
-	}
-
-	writer.WriteHeader(http.StatusAccepted)
+	//TODO implement me using TDD
+	writer.WriteHeader(http.StatusNotImplemented)
 }

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -503,72 +503,7 @@ func TestHttpController_ExportRecordedData(t *testing.T) {
 }
 
 func TestHttpController_ImportRecordedData(t *testing.T) {
-	target, mockDataManager, _ := createTargetAndMocks()
-
-	handler := http.HandlerFunc(target.importRecordedData)
-
-	emptyDataRequest := dtos.RecordedData{}
-
-	recordedEventRequest := dtos.RecordedData{
-		RecordedEvents: []coreDtos.Event{
-			coreDtos.Event{
-				DeviceName:  "test",
-				ProfileName: "test",
-				Readings: []coreDtos.BaseReading{
-					coreDtos.BaseReading{
-						SimpleReading: coreDtos.SimpleReading{
-							Value: "1456.0",
-						},
-					},
-				},
-			},
-			coreDtos.Event{
-				DeviceName:  "test",
-				ProfileName: "test",
-				Readings: []coreDtos.BaseReading{
-					coreDtos.BaseReading{
-						SimpleReading: coreDtos.SimpleReading{
-							Value: "1457.0",
-						},
-					},
-				},
-			},
-		},
-		Devices: []coreDtos.Device{
-			coreDtos.Device{
-				Name:        "test_device",
-				ProfileName: "test",
-			},
-		},
-	}
-	tests := []struct {
-		Name             string
-		ExpectedResponse dtos.RecordedData
-		ExpectedStatus   int
-		ExpectedError    error
-	}{
-		{
-			Name: "valid - data with 2 events",
-			ExpectedResponse: recordedEventRequest,
-			ExpectedStatus: http.StatusAccepted,
-			ExpectedError: nil,
-		},
-		
-	}
-	for _, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
-			mockDataManager.On("ImportRecordedData", mock.Anything).Return(test.ExpectedError).Once()
-
-			req, err := http.NewRequest(http.MethodPost, dataRoute, nil)
-			require.NoError(t, err)
-
-			testRecorder := httptest.NewRecorder()
-			handler.ServeHTTP(testRecorder, req)
-
-			require.Equal(t, test.ExpectedStatus, testRecorder.Code)
-		})
-	}
-
+	// TODO: Implement using TDD
 }
 
 func marshal(t *testing.T, v any) []byte {

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -503,7 +503,72 @@ func TestHttpController_ExportRecordedData(t *testing.T) {
 }
 
 func TestHttpController_ImportRecordedData(t *testing.T) {
-	// TODO: Implement using TDD
+	target, mockDataManager, _ := createTargetAndMocks()
+
+	handler := http.HandlerFunc(target.importRecordedData)
+
+	emptyDataRequest := dtos.RecordedData{}
+
+	recordedEventRequest := dtos.RecordedData{
+		RecordedEvents: []coreDtos.Event{
+			coreDtos.Event{
+				DeviceName:  "test",
+				ProfileName: "test",
+				Readings: []coreDtos.BaseReading{
+					coreDtos.BaseReading{
+						SimpleReading: coreDtos.SimpleReading{
+							Value: "1456.0",
+						},
+					},
+				},
+			},
+			coreDtos.Event{
+				DeviceName:  "test",
+				ProfileName: "test",
+				Readings: []coreDtos.BaseReading{
+					coreDtos.BaseReading{
+						SimpleReading: coreDtos.SimpleReading{
+							Value: "1457.0",
+						},
+					},
+				},
+			},
+		},
+		Devices: []coreDtos.Device{
+			coreDtos.Device{
+				Name:        "test_device",
+				ProfileName: "test",
+			},
+		},
+	}
+	tests := []struct {
+		Name             string
+		ExpectedResponse dtos.RecordedData
+		ExpectedStatus   int
+		ExpectedError    error
+	}{
+		{
+			Name: "valid - data with 2 events",
+			ExpectedResponse: recordedEventRequest,
+			ExpectedStatus: http.StatusAccepted,
+			ExpectedError: nil,
+		},
+		
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			mockDataManager.On("ImportRecordedData", mock.Anything).Return(test.ExpectedError).Once()
+
+			req, err := http.NewRequest(http.MethodPost, dataRoute, nil)
+			require.NoError(t, err)
+
+			testRecorder := httptest.NewRecorder()
+			handler.ServeHTTP(testRecorder, req)
+
+			require.Equal(t, test.ExpectedStatus, testRecorder.Code)
+		})
+	}
+
 }
 
 func marshal(t *testing.T, v any) []byte {

--- a/internal/controller/recordedDataJsonUncompressed.json
+++ b/internal/controller/recordedDataJsonUncompressed.json
@@ -1,0 +1,62 @@
+{
+  "recordedEvents": [
+    {
+      "apiVersion": "",
+      "id": "",
+      "deviceName": "test",
+      "profileName": "test",
+      "sourceName": "",
+      "origin": 0,
+      "readings": [
+        {
+          "origin": 0,
+          "deviceName": "",
+          "resourceName": "",
+          "profileName": "",
+          "valueType": "",
+          "value": "1456.0"
+        }
+      ]
+    },
+    {
+      "apiVersion": "",
+      "id": "",
+      "deviceName": "test",
+      "profileName": "test",
+      "sourceName": "",
+      "origin": 0,
+      "readings": [
+        {
+          "origin": 0,
+          "deviceName": "",
+          "resourceName": "",
+          "profileName": "",
+          "valueType": "",
+          "value": "1457.0"
+        }
+      ]
+    }
+  ],
+  "profiles": [
+    {
+      "id": "",
+      "name": "test",
+      "manufacturer": "",
+      "description": "",
+      "model": "",
+      "labels": null,
+      "deviceResources": null,
+      "deviceCommands": null
+    }
+  ],
+  "devices": [
+    {
+      "name": "test_device",
+      "adminState": "",
+      "operatingState": "",
+      "serviceName": "",
+      "profileName": "test",
+      "protocols": null
+    }
+  ]
+}

--- a/internal/interfaces/manager.go
+++ b/internal/interfaces/manager.go
@@ -38,5 +38,5 @@ type DataManager interface {
 	ExportRecordedData() (*dtos.RecordedData, error)
 	// ImportRecordedData imports data from a previously exported record session.
 	// An error is returned if a record or replay session is currently running or the data is incomplete
-	ImportRecordedData(data *dtos.RecordedData) error
+	ImportRecordedData(data *dtos.RecordedData, overwrite bool) error
 }

--- a/internal/interfaces/manager.go
+++ b/internal/interfaces/manager.go
@@ -37,6 +37,7 @@ type DataManager interface {
 	// An error is returned if the no record session was run or a record session is currently running
 	ExportRecordedData() (*dtos.RecordedData, error)
 	// ImportRecordedData imports data from a previously exported record session.
+	// If overwrite parameter is true then Device Profiles and/or Devices will be overwritten.
 	// An error is returned if a record or replay session is currently running or the data is incomplete
 	ImportRecordedData(data *dtos.RecordedData, overwrite bool) error
 }

--- a/internal/interfaces/mocks/DataManager.go
+++ b/internal/interfaces/mocks/DataManager.go
@@ -67,13 +67,13 @@ func (_m *DataManager) ExportRecordedData() (*dtos.RecordedData, error) {
 	return r0, r1
 }
 
-// ImportRecordedData provides a mock function with given fields: data
-func (_m *DataManager) ImportRecordedData(data *dtos.RecordedData) error {
-	ret := _m.Called(data)
+// ImportRecordedData provides a mock function with given fields: data, overwrite
+func (_m *DataManager) ImportRecordedData(data *dtos.RecordedData, overwrite bool) error {
+	ret := _m.Called(data, overwrite)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*dtos.RecordedData) error); ok {
-		r0 = rf(data)
+	if rf, ok := ret.Get(0).(func(*dtos.RecordedData, bool) error); ok {
+		r0 = rf(data, overwrite)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Run non-secure EdgeX stack
Run make build
Run app service with -cp -d

Use postman collecting to test Post to localhost:59712/api/v3/replay
1. set body to binary and select text file
    1.  for compressed file then add `Content-Encoding` header and add the value `gzip` or `deflate` (if file is zlib)
    2.  for uncompressed `Content-Encoding` should be left blank
    3.  set `Content-Type` header to `application/json`
4. when tested a internal server error status with the message `Import data failed: not implemented` will be returned as  ImportRecordedData has not been implemented yet



## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->
[recordedDataJsonUncompressed.txt](https://github.com/edgexfoundry/app-record-replay/files/12402661/recordedDataJsonUncompressed.txt)
