### PR TITLE
feat: Implement app layer Cancel Replay

### DIFF
--- a/internal/application/manager_test.go
+++ b/internal/application/manager_test.go
@@ -772,7 +772,6 @@ func TestDataManager_CancelReplay(t *testing.T) {
 			mockLogger := &loggerMocks.LoggingClient{}
 			mockLogger.On("Debug", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			mockLogger.On("Debugf", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-			//mockLogger.On("Errorf", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 			mockSdk := &mocks.ApplicationService{}
 			mockSdk.On("LoggingClient").Return(mockLogger)


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **Not Yet**
  <link to docs PR>

## Testing Instructions
From compose builder run `make run no-secty ds-virtual` 
Build app service
run `WRITABLE_LOGLEVEL=DEBUG ./app-record-replay -cp -d -o | grep "ARR "` to run app service 
Send DELETE to  `localhost:59712/api/v3/replay` 
Verify response is a 500 status code with the message `failed to cancel replay: no replay currently running`
```
Send POST the following to `localhost:59712/api/v3/record` to record data
{
    "duration" : 60000000000,
    "eventLimit" : 100
}
After ~ 1min once logs shows :
```
ARR Process Recorded Data: X events in Zs have been saved for replay
```
Send Get to `localhost:59712/api/v3/record`
Verify response is a 200 with:
```
{"inProgress":false,"eventCount":x,"duration":y}
```
Stop the Device Virtual container
Send POST to `localhost:59712/api/v3/replay` with the following
```
{
    "replayRate" : 1,
    "repeatCount" : 1000
}
```
Then send GET to  `localhost:59712/api/v3/replay` 
Verify response code is 200 and body is something like
```
{"running":true,"eventCount":x,"duration":y,"repeatCount":z,"ErrorMessage":""}
```
Then send DELETE to  `localhost:59712/api/v3/replay` 
Verify response is a 202
Then send GET to  `localhost:59712/api/v3/replay` 
Verify response code is 200 and body is something like
```
{"running":false,"eventCount":11,"duration":0,"repeatCount":0,"ErrorMessage":"replay canceled"}
```


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->