### PR TITLE
feat: Implement app layer Export

### DIFF
--- a/internal/application/manager.go
+++ b/internal/application/manager.go
@@ -446,7 +446,7 @@ func (m *dataManager) ExportRecordedData() (*dtos.RecordedData, error) {
 	if len(m.recordedData.Devices) == 0 {
 		uniqueDevices := make(map[string]bool)
 		for _, event := range m.recordedData.Events {
-			if uniqueDevices[event.DeviceName] == false {
+			if !uniqueDevices[event.DeviceName] {
 				response, err := m.appSvc.DeviceClient().DeviceByName(context.Background(), event.DeviceName)
 				if err != nil {
 					m.recordedData.Devices = []coreDtos.Device{}
@@ -464,7 +464,7 @@ func (m *dataManager) ExportRecordedData() (*dtos.RecordedData, error) {
 	if len(m.recordedData.Profiles) == 0 {
 		uniqueProfiles := make(map[string]bool)
 		for _, device := range m.recordedData.Devices {
-			if uniqueProfiles[device.ProfileName] == false {
+			if !uniqueProfiles[device.ProfileName] {
 				response, err := m.appSvc.DeviceProfileClient().DeviceProfileByName(context.Background(), device.ProfileName)
 				if err != nil {
 					m.recordedData.Profiles = []coreDtos.DeviceProfile{}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -52,9 +52,9 @@ const (
 	noDataFound                    = "no recorded data found"
 
 	noCompression       = ""
-	zlibCompression     = "ZLIB"
-	gzipCompression     = "GZIP"
-	contenEncodingGzip  = "gzip"
+	zlibCompression     = "zlib"
+	gzipCompression     = "gzip"
+	contentEncodingGzip = "gzip"
 	contentEncodingZlib = "deflate" // standard value used for zlib is deflate
 )
 
@@ -252,7 +252,7 @@ func (c *httpController) exportRecordedData(writer http.ResponseWriter, request 
 		_, _ = writer.Write(jsonResponse)
 
 	case zlibCompression:
-		writer.Header().Set("Content-Encoding", "ZLIB")
+		writer.Header().Set("Content-Encoding", contentEncodingZlib)
 		writer.Header().Set("Content-Type", "application/json")
 		zlibWriter := zlib.NewWriter(writer)
 		defer zlibWriter.Close()
@@ -262,10 +262,9 @@ func (c *httpController) exportRecordedData(writer http.ResponseWriter, request 
 			_, _ = writer.Write([]byte(fmt.Sprintf("%s %s: %s", failedDataCompression, zlibCompression, err)))
 			return
 		}
-		writer.WriteHeader(http.StatusOK)
 
 	case gzipCompression:
-		writer.Header().Set("Content-Encoding", "GZIP")
+		writer.Header().Set("Content-Encoding", contentEncodingGzip)
 		writer.Header().Set("Content-Type", "application/json")
 		gZipWriter := gzip.NewWriter(writer)
 		defer gZipWriter.Close()
@@ -275,7 +274,6 @@ func (c *httpController) exportRecordedData(writer http.ResponseWriter, request 
 			_, _ = writer.Write([]byte(fmt.Sprintf("%s %s: %s", failedDataCompression, gzipCompression, err)))
 			return
 		}
-		writer.WriteHeader(http.StatusOK)
 
 	default:
 		writer.WriteHeader(http.StatusInternalServerError)
@@ -318,7 +316,7 @@ func (c *httpController) importRecordedData(writer http.ResponseWriter, request 
 	case noCompression:
 		reader = request.Body
 
-	case contenEncodingGzip:
+	case contentEncodingGzip:
 		reader, err = gzip.NewReader(request.Body)
 		if err != nil {
 			writer.WriteHeader(http.StatusBadRequest)

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -384,9 +384,6 @@ func TestHttpController_CancelReplay(t *testing.T) {
 }
 
 func TestHttpController_ExportRecordedData(t *testing.T) {
-	target, mockDataManager, _ := createTargetAndMocks()
-
-	handler := http.HandlerFunc(target.exportRecordedData)
 
 	noRecordedData := dtos.RecordedData{}
 
@@ -454,14 +451,14 @@ func TestHttpController_ExportRecordedData(t *testing.T) {
 			ExpectedResponse: &recordedData,
 			ExpectedStatus:   http.StatusOK,
 			ExpectedError:    nil,
-			QueryParam:       "GZIP",
+			QueryParam:       gzipCompression,
 		},
 		{
 			Name:             "Valid with data with ZLIB query parameter",
 			ExpectedResponse: &recordedData,
 			ExpectedStatus:   http.StatusOK,
 			ExpectedError:    nil,
-			QueryParam:       "ZLIB",
+			QueryParam:       zlibCompression,
 		},
 		{
 			Name:             "Valid with data with invalid GZ query parameter",
@@ -473,7 +470,10 @@ func TestHttpController_ExportRecordedData(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			mockDataManager.On("ExportRecordedData").Return(test.ExpectedResponse, test.ExpectedError).Once()
+			target, mockDataManager, _ := createTargetAndMocks()
+			mockDataManager.On("ExportRecordedData").Return(test.ExpectedResponse, test.ExpectedError)
+
+			handler := http.HandlerFunc(target.exportRecordedData)
 
 			req, err := http.NewRequest(http.MethodGet, dataRoute, nil)
 			require.NoError(t, err)
@@ -690,13 +690,13 @@ func createTargetAndMocks() (*httpController, *mocks.DataManager, *appMocks.Appl
 func uncompressData(t *testing.T, compressionType string, r io.Reader) *dtos.RecordedData {
 	data := dtos.RecordedData{}
 	switch compressionType {
-	case "GZIP":
+	case gzipCompression:
 		reader, err := gzip.NewReader(r)
 		require.NoError(t, err)
 		defer reader.Close()
 		err = json.NewDecoder(reader).Decode(&data)
 		require.NoError(t, err)
-	case "ZLIB":
+	case zlibCompression:
 		reader, err := zlib.NewReader(r)
 		require.NoError(t, err)
 		defer reader.Close()

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -586,7 +586,7 @@ func TestHttpController_ImportRecordedData(t *testing.T) {
 		},
 		{
 			Name:             "valid - data with 2 events and compressed gzip",
-			ContentEncoding:  contenEncodingGzip,
+			ContentEncoding:  contentEncodingGzip,
 			ExpectedResponse: compressData(t, "GZIP", recordedEventRequest),
 			ExpectedStatus:   http.StatusAccepted,
 			ExpectedError:    nil,
@@ -604,7 +604,7 @@ func TestHttpController_ImportRecordedData(t *testing.T) {
 		},
 		{
 			Name:             "valid - data with 2 events and compressed gzip w/ overwrite set to true",
-			ContentEncoding:  contenEncodingGzip,
+			ContentEncoding:  contentEncodingGzip,
 			ExpectedResponse: compressData(t, "GZIP", recordedEventRequest),
 			ExpectedStatus:   http.StatusAccepted,
 			ExpectedError:    nil,


### PR DESCRIPTION
closes #8

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **Not Yet**
  <link to docs PR>

## Testing Instructions
From compose builder run `make run no-secty ds-virtual` 
Build app service
run `WRITABLE_LOGLEVEL=DEBUG ./app-record-replay -cp -d -o | grep "ARR "` to run app service 
Send GET the following to `localhost:59712/api/v3/record` 
Verify 500 error response with following message:
```
failed to export recorded data: no recorded data present
```
Send POST the following to `localhost:59712/api/v3/record` to record data
{
    "duration" : 60000000000,
    "eventLimit" : 10
}
After less than 1min logs shows :
```
ARR Process Recorded Data: 10 events in Zs have been saved for replay
```
Send GET the following to `localhost:59712/api/v3/record` using PostMan
Verify 200 response code with JSON containing exactly 10 events and 1 or more Profiles and one or more Devices
Verify Header `Content-Type` is `application/json`
Send GET the following to `localhost:59712/api/v3/record?compression=gzip` using PostMan
Verify 200 response code with JSON containing exactly same data as previously (note that PostMan decompresses the data)
Verify Header `Content-Type` is `application/json` and `Content-Encoding` is `gzip`
Send GET the following to `localhost:59712/api/v3/record?compression=zlib` using PostMan
Verify 200 response code with JSON containing exactly same data as previously (note that PostMan decompresses the data)
Verify Header `Content-Type` is `application/json` and `Content-Encoding` is `deflate`


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->