### PR TITLE
fix: Add missing service name to the replay publish topic

### DIFF
--- a/internal/application/manager_test.go
+++ b/internal/application/manager_test.go
@@ -18,6 +18,7 @@ package application
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -560,8 +561,13 @@ func TestDataManager_StartReplay_Cancel(t *testing.T) {
 			mockLogger.On("Debugf", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			mockLogger.On("Errorf", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
+			mockDeviceClient := &clientMocks.DeviceClient{}
+			mockDeviceClient.On("DeviceByName", mock.Anything, mock.Anything).
+				Return(responses.DeviceResponse{Device: coreDtos.Device{Name: "D1", ServiceName: expectedServiceName}}, nil)
+
 			mockSdk := &mocks.ApplicationService{}
 			mockSdk.On("LoggingClient").Return(mockLogger)
+			mockSdk.On("DeviceClient").Return(mockDeviceClient)
 			mockSdk.On("AppContext").Return(appCtx)
 			mockSdk.On("PublishWithTopic", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
@@ -672,8 +678,13 @@ func TestDataManager_ReplayStatus(t *testing.T) {
 			mockLogger.On("Debugf", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			mockLogger.On("Errorf", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
+			mockDeviceClient := &clientMocks.DeviceClient{}
+			mockDeviceClient.On("DeviceByName", mock.Anything, mock.Anything).
+				Return(responses.DeviceResponse{Device: coreDtos.Device{Name: "D1", ServiceName: expectedServiceName}}, nil)
+
 			mockSdk := &mocks.ApplicationService{}
 			mockSdk.On("LoggingClient").Return(mockLogger)
+			mockSdk.On("DeviceClient").Return(mockDeviceClient)
 			mockSdk.On("AppContext").Return(context.Background())
 			mockSdk.On("PublishWithTopic", mock.Anything, mock.Anything, mock.Anything).Return(test.ExpectedReplayError)
 
@@ -783,8 +794,13 @@ func TestDataManager_CancelReplay(t *testing.T) {
 			mockLogger.On("Debug", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			mockLogger.On("Debugf", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
+			mockDeviceClient := &clientMocks.DeviceClient{}
+			mockDeviceClient.On("DeviceByName", mock.Anything, mock.Anything).
+				Return(responses.DeviceResponse{Device: coreDtos.Device{Name: "D1", ServiceName: expectedServiceName}}, nil)
+
 			mockSdk := &mocks.ApplicationService{}
 			mockSdk.On("LoggingClient").Return(mockLogger)
+			mockSdk.On("DeviceClient").Return(mockDeviceClient)
 			mockSdk.On("AppContext").Return(context.Background())
 			mockSdk.On("PublishWithTopic", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
@@ -1006,7 +1022,29 @@ func TestDataManager_ExportRecordedData(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, *test.ExpectedExportedData, *actualExportedData)
+
+			// Since actual data may not be in the same order as the expected data, we must compare element individually
+			// Events should be in the expected order, but devices and profile were created from a map which can have random ordering.
+			assert.Equal(t, test.ExpectedExportedData.RecordedEvents, actualExportedData.RecordedEvents)
+			for _, expectedDevice := range test.ExpectedExportedData.Devices {
+				found := false
+				for _, actualDevice := range actualExportedData.Devices {
+					if actualDevice.Name == expectedDevice.Name {
+						found = true
+					}
+				}
+				assert.True(t, found, fmt.Sprintf("Expected device %s not found in actual devices: %v", expectedDevice.Name, actualExportedData.Devices))
+			}
+			for _, expectedProfile := range test.ExpectedExportedData.Profiles {
+				found := false
+				for _, actualProfile := range actualExportedData.Profiles {
+					if actualProfile.Name == expectedProfile.Name {
+						found = true
+					}
+				}
+				assert.True(t, found, fmt.Sprintf("Expected profile %s not found in actual profiles: %v", expectedProfile.Name, actualExportedData.Profiles))
+			}
+
 		})
 	}
 }


### PR DESCRIPTION
closes #65

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Record data from Device Virtual
Replay the data and verify the replayed data is published to `edgex/events/device-virtual/#`

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->