### PR TITLE
feat: Implement app layer Import

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -241,6 +241,7 @@ func (c *httpController) exportRecordedData(writer http.ResponseWriter, request 
 	compression := request.URL.Query().Get("compression")
 	switch compression {
 	case noCompression:
+		c.appSdk.LoggingClient().Debug("ARR Export - Exporting as JSON w/o compression")
 		jsonResponse, err := json.Marshal(recordedData)
 		if err != nil {
 			writer.WriteHeader(http.StatusInternalServerError)
@@ -252,6 +253,7 @@ func (c *httpController) exportRecordedData(writer http.ResponseWriter, request 
 		_, _ = writer.Write(jsonResponse)
 
 	case zlibCompression:
+		c.appSdk.LoggingClient().Debug("ARR Export - Exporting as JSON using ZLIB compression")
 		writer.Header().Set("Content-Encoding", contentEncodingZlib)
 		writer.Header().Set("Content-Type", "application/json")
 		zlibWriter := zlib.NewWriter(writer)
@@ -264,6 +266,7 @@ func (c *httpController) exportRecordedData(writer http.ResponseWriter, request 
 		}
 
 	case gzipCompression:
+		c.appSdk.LoggingClient().Debug("ARR Export - Exporting as JSON using GZIP compression")
 		writer.Header().Set("Content-Encoding", contentEncodingGzip)
 		writer.Header().Set("Content-Type", "application/json")
 		gZipWriter := gzip.NewWriter(writer)
@@ -314,9 +317,11 @@ func (c *httpController) importRecordedData(writer http.ResponseWriter, request 
 	switch compression {
 
 	case noCompression:
+		c.appSdk.LoggingClient().Debug("ARR Import - Importing as JSON w/o compression")
 		reader = request.Body
 
 	case contentEncodingGzip:
+		c.appSdk.LoggingClient().Debug("ARR Import - Importing as JSON using GZIP compression")
 		reader, err = gzip.NewReader(request.Body)
 		if err != nil {
 			writer.WriteHeader(http.StatusBadRequest)
@@ -325,6 +330,7 @@ func (c *httpController) importRecordedData(writer http.ResponseWriter, request 
 		}
 
 	case contentEncodingZlib:
+		c.appSdk.LoggingClient().Debug("ARR Import - Importing as JSON using ZLIB compression")
 		reader, err = zlib.NewReader(request.Body)
 		if err != nil {
 			writer.WriteHeader(http.StatusBadRequest)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,0 +1,37 @@
+//
+// Copyright (c) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package utils
+
+// SliceToMap converts a Slice of T to a Map of pointer to T where
+// the key is a string retrieved by the passed in keyFunc
+func SliceToMap[T any](slice []T, keyFunc func(T) string) map[string]*T {
+	m := make(map[string]*T)
+	for index, item := range slice {
+		m[keyFunc(item)] = &slice[index]
+	}
+	return m
+}
+
+// MapToSlice converts a Map of pointer to T to a SLice of T
+func MapToSlice[T any](m map[string]*T) []T {
+	slice := make([]T, 0)
+	for _, item := range m {
+		slice = append(slice, *item)
+	}
+
+	return slice
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,0 +1,52 @@
+//
+// Copyright (c) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package utils
+
+import (
+	"testing"
+
+	coreDtos "github.com/edgexfoundry/go-mod-core-contracts/v3/dtos"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSliceToMap(t *testing.T) {
+	input := []coreDtos.Device{
+		{Name: "D1"},
+		{Name: "D2"},
+		{Name: "D3"},
+	}
+
+	actual := SliceToMap(input, func(d coreDtos.Device) string { return d.Name })
+	assert.Len(t, actual, len(input))
+	for _, item := range input {
+		assert.NotNil(t, actual[item.Name])
+	}
+}
+
+func TestMapToSlice(t *testing.T) {
+	input := map[string]*coreDtos.Device{
+		"D1": {Name: "D1"},
+		"D2": {Name: "D2"},
+		"D3": {Name: "D3"},
+	}
+
+	actual := MapToSlice(input)
+	assert.Len(t, actual, len(input))
+	for _, item := range actual {
+		assert.NotNil(t, input[item.Name])
+	}
+}

--- a/pkg/dtos/replay.go
+++ b/pkg/dtos/replay.go
@@ -39,6 +39,6 @@ type ReplayStatus struct {
 	Duration time.Duration `json:"duration"`
 	// RepeatCount is the number of times the replay of the recorded data has been completed.
 	RepeatCount int `json:"repeatCount"`
-	// ErrorMessage contains the error message if an error occurred during replay
-	ErrorMessage string
+	// Message, if set, contains the message describing the response.
+	Message string
 }


### PR DESCRIPTION
closes #6

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **TBD**
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
From compose builder run `make run no-secty ds-virtual` 
Build app service
run `WRITABLE_LOGLEVEL=DEBUG ./app-record-replay -cp -d -o | grep "ARR "` to run app service 
Send POST the following to `localhost:59712/api/v3/record` to record data
{
    "duration" : 60000000000,
    "eventLimit" : 10
}
After less than 1min logs shows :
```
ARR Process Recorded Data: 10 events in Zs have been saved for replay
```
Run `curl localhost:59712/api/v3/data -o test.json`
Verify logs contain:
```
level=DEBUG ts=2023-08-28T22:51:46.075333336Z app=app-record-replay source=manager.go:465 msg="ARR Export: Loaded 3 devices for export"
level=DEBUG ts=2023-08-28T22:51:46.080144964Z app=app-record-replay source=manager.go:482 msg="ARR Export: Loaded 3 devices profiles for export"     
level=DEBUG ts=2023-08-28T22:51:46.080179064Z app=app-record-replay source=manager.go:485 msg="ARR Export: Exporting 10 events, 3 devices and 3 device profiles"
level=DEBUG ts=2023-08-28T22:51:46.080191064Z app=app-record-replay source=controller.go:244 msg="ARR Export - Exporting as JSON w/o compression"
```
run `curl localhost:59712/api/v3/data?compression=gzip -o test.gz`
Verify logs contain:
```
level=DEBUG ts=2023-08-28T22:53:46.282936979Z app=app-record-replay source=manager.go:485 msg="ARR Export: Exporting 10 events, 3 devices and 3 device profiles"
level=DEBUG ts=2023-08-28T22:53:46.282986479Z app=app-record-replay source=controller.go:269 msg="ARR Export - Exporting as JSON using GZIP compression"
```
run `curl localhost:59712/api/v3/data?compression=zlib -o test.zlib`
Verify logs contain:
```
level=DEBUG ts=2023-08-28T22:55:36.990875904Z app=app-record-replay source=manager.go:485 msg="ARR Export: Exporting 10 events, 3 devices and 3 device profiles"
level=DEBUG ts=2023-08-28T22:55:36.990915004Z app=app-record-replay source=controller.go:256 msg="ARR Export - Exporting as JSON using ZLIB compression"
```
run `curl -d @./test.json  localhost:59712/api/v3/data -H "Content-Type: application/json"`
Verify logs contain:
```
level=DEBUG ts=2023-08-28T22:58:29.269147886Z app=app-record-replay source=controller.go:320 msg="ARR Import - Importing as JSON w/o compression"    
level=DEBUG ts=2023-08-28T22:58:29.272133214Z app=app-record-replay source=manager.go:624 msg="ARR Import: Existing device profile Random-Integer-Device not updated: Can not update existing device profiles"
level=DEBUG ts=2023-08-28T22:58:29.273312025Z app=app-record-replay source=manager.go:624 msg="ARR Import: Existing device profile Random-UnsignedInteger-Device not updated: Can not update existing device profiles"
level=DEBUG ts=2023-08-28T22:58:29.274273234Z app=app-record-replay source=manager.go:624 msg="ARR Import: Existing device profile Random-Boolean-Device not updated: Can not update existing device profiles"
level=DEBUG ts=2023-08-28T22:58:29.278831577Z app=app-record-replay source=manager.go:591 msg="ARR Import: Updated existing device Random-UnsignedInteger-Device"
level=DEBUG ts=2023-08-28T22:58:29.284153527Z app=app-record-replay source=manager.go:591 msg="ARR Import: Updated existing device Random-Boolean-Device"
level=DEBUG ts=2023-08-28T22:58:29.289430277Z app=app-record-replay source=manager.go:591 msg="ARR Import: Updated existing device Random-Integer-Device"
level=DEBUG ts=2023-08-28T22:58:29.289491077Z app=app-record-replay source=manager.go:543 msg="ARR Import: Imported 10 events, 3 devices and 3 device profiles"
```
run `curl --data-binary @./test.gz  localhost:59712/api/v3/data -H "Content-Type: application/json" -H "Content-Encoding: gzip"`
Verify logs contain:
```
level=DEBUG ts=2023-08-28T23:03:36.252922385Z app=app-record-replay source=controller.go:324 msg="ARR Import - Importing as JSON using GZIP compression"
level=DEBUG ts=2023-08-28T23:03:36.257091323Z app=app-record-replay source=manager.go:624 msg="ARR Import: Existing device profile Random-Boolean-Device not updated: Can not update existing device profiles"
level=DEBUG ts=2023-08-28T23:03:36.258694937Z app=app-record-replay source=manager.go:624 msg="ARR Import: Existing device profile Random-Integer-Device not updated: Can not update existing device profiles"
level=DEBUG ts=2023-08-28T23:03:36.260214251Z app=app-record-replay source=manager.go:624 msg="ARR Import: Existing device profile Random-UnsignedInteger-Device not updated: Can not update existing device profiles"
level=DEBUG ts=2023-08-28T23:03:36.265608599Z app=app-record-replay source=manager.go:591 msg="ARR Import: Updated existing device Random-Integer-Device"
level=DEBUG ts=2023-08-28T23:03:36.270789146Z app=app-record-replay source=manager.go:591 msg="ARR Import: Updated existing device Random-UnsignedInteger-Device"
level=DEBUG ts=2023-08-28T23:03:36.275482288Z app=app-record-replay source=manager.go:591 msg="ARR Import: Updated existing device Random-Boolean-Device"
level=DEBUG ts=2023-08-28T23:03:36.275553889Z app=app-record-replay source=manager.go:543 msg="ARR Import: Imported 10 events, 3 devices and 3 device profiles"
```
run `curl --data-binary @./test.zlib  localhost:59712/api/v3/data -H "Content-Type: application/json" -H "Content-Encoding: deflate"`
Verify logs contain:
```
level=DEBUG ts=2023-08-28T23:05:23.862386936Z app=app-record-replay source=controller.go:333 msg="ARR Import - Importing as JSON using ZLIB compression"
level=DEBUG ts=2023-08-28T23:05:23.866583049Z app=app-record-replay source=manager.go:624 msg="ARR Import: Existing device profile Random-Boolean-Device not updated: Can not update existing device profiles"
level=DEBUG ts=2023-08-28T23:05:23.868427154Z app=app-record-replay source=manager.go:624 msg="ARR Import: Existing device profile Random-Integer-Device not updated: Can not update existing device profiles"level=DEBUG ts=2023-08-28T23:05:23.87018926Z app=app-record-replay source=manager.go:624 msg="ARR Import: Existing device profile Random-UnsignedInteger-Device not updated: Can not update existing device profiles"
level=DEBUG ts=2023-08-28T23:05:23.875848277Z app=app-record-replay source=manager.go:591 msg="ARR Import: Updated existing device Random-Boolean-Device"
level=DEBUG ts=2023-08-28T23:05:23.881492094Z app=app-record-replay source=manager.go:591 msg="ARR Import: Updated existing device Random-Integer-Device"
level=DEBUG ts=2023-08-28T23:05:23.887376812Z app=app-record-replay source=manager.go:591 msg="ARR Import: Updated existing device Random-UnsignedInteger-Device"
level=DEBUG ts=2023-08-28T23:05:23.887476613Z app=app-record-replay source=manager.go:543 msg="ARR Import: Imported 10 events, 3 devices and 3 device profiles"
```
run `curl -d @./test.json  localhost:59712/api/v3/data?overwire=false -H "Content-Type: application/json"`
Verify logs **JUST** contain (i.e no messages about Devices or Profiles:
```
level=DEBUG ts=2023-08-28T23:07:57.325709862Z app=app-record-replay source=controller.go:320 msg="ARR Import - Importing as JSON w/o compression"    
level=DEBUG ts=2023-08-28T23:07:57.334123988Z app=app-record-replay source=manager.go:543 msg="ARR Import: Imported 10 events, 3 devices and 3 device profiles"
```
From EdgeX UI remove all the Devices and then remove all the Device Profiles
run `curl -d @./test.json  localhost:59712/api/v3/data?overwire=false -H "Content-Type: application/json"`
Verify logs contain add messages for  Devices or Profiles:
```
level=DEBUG ts=2023-08-28T23:22:37.943454305Z app=app-record-replay source=controller.go:320 msg="ARR Import - Importing as JSON w/o compression"
level=DEBUG ts=2023-08-28T23:22:37.950126946Z app=app-record-replay source=manager.go:614 msg="ARR Import: Add new device profile Random-Integer-Device"
level=DEBUG ts=2023-08-28T23:22:37.953212966Z app=app-record-replay source=manager.go:614 msg="ARR Import: Add new device profile Random-UnsignedInteger-Device"
level=DEBUG ts=2023-08-28T23:22:37.955899182Z app=app-record-replay source=manager.go:614 msg="ARR Import: Add new device profile Random-Boolean-Device"
level=DEBUG ts=2023-08-28T23:22:37.960826412Z app=app-record-replay source=manager.go:563 msg="ARR Import: Added new device Random-UnsignedInteger-Device"
level=DEBUG ts=2023-08-28T23:22:37.96527644Z app=app-record-replay source=manager.go:563 msg="ARR Import: Added new device Random-Boolean-Device"
level=DEBUG ts=2023-08-28T23:22:37.969019363Z app=app-record-replay source=manager.go:563 msg="ARR Import: Added new device Random-Integer-Device"
level=DEBUG ts=2023-08-28T23:22:37.969071563Z app=app-record-replay source=manager.go:543 msg="ARR Import: Imported 10 events, 3 devices and 3 device profiles"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->