### PR TITLE
refactor: Check for 404 before Adding Profile

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -239,3 +239,21 @@ https://github.com/klauspost/compress/blob/master/LICENSE
 
 golang.org/x/exp (BSD-3) https://github.com/golang/tools
 https://github.com/golang/tools/blob/master/LICENSE
+
+github.com/golang-jwt/jwt/v4 (MIT) github.com/golang-jwt/jwt
+https://github.com/golang-jwt/jwt/blob/main/LICENSE
+
+github.com/labstack/echo/v4 (MIT) https://github.com/labstack/echo
+https://github.com/labstack/echo/blob/master/LICENSE
+
+github.com/labstack/gommon (MIT) https://github.com/labstack/gommon
+https://github.com/labstack/gommon/blob/master/LICENSE
+
+github.com/valyala/fasttemplate (MIT) https://github.com/valyala/fasttemplate
+https://github.com/valyala/fasttemplate/blob/master/LICENSE
+
+github.com/valyala/bytebufferpool (MIT) https://github.com/valyala/bytebufferpool
+https://github.com/valyala/bytebufferpool/blob/master/LICENSE
+
+golang.org/x/time (Unspecified) https://github.com/golang/time
+https://github.com/golang/text/blob/master/LICENSE

--- a/internal/application/manager.go
+++ b/internal/application/manager.go
@@ -602,10 +602,9 @@ func (m *dataManager) uploadProfiles(profiles []coreDtos.DeviceProfile, overwrit
 			return fmt.Errorf("failed check if profile %s exists in system: %w", profile.Name, err)
 		}
 
-		addRequest := requests.NewDeviceProfileRequest(profile)
+		if err != nil && err.Code() == http.StatusNotFound {
+			addRequest := requests.NewDeviceProfileRequest(profile)
 
-		// If got here with an err then the Device Profile doesn't exist in the system, so must add it.
-		if err != nil {
 			_, err = profileClient.Add(context.Background(), []requests.DeviceProfileRequest{addRequest})
 			if err != nil {
 				return fmt.Errorf("failed to add device profile %s to system: %w", profile.Name, err)

--- a/internal/application/manager_test.go
+++ b/internal/application/manager_test.go
@@ -987,8 +987,6 @@ func TestDataManager_ImportRecordedData_NoDataErrors(t *testing.T) {
 			mockProfileClient.On("DeviceProfileByName", mock.Anything, "P2").
 				Return(responses.DeviceProfileResponse{}, nil)
 			mockProfileClient.On("Add", mock.Anything, mock.Anything).Return(nil, nil)
-			mockProfileClient.On("DeleteByName", mock.Anything, mock.Anything).
-				Return(commonDTO.BaseResponse{}, nil)
 
 			mockLogger := &loggerMocks.LoggingClient{}
 			mockLogger.On("Debugf", mock.Anything, mock.Anything, mock.Anything, mock.Anything)


### PR DESCRIPTION
closes #71

Also had to update Attribution.txt due to latest ADK in use.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **Existing suffice**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **TBD**
  <link to docs PR>

## Testing Instructions
From compose builder run `make run no-secty ds-virtual` 
Build app service
run `WRITABLE_LOGLEVEL=DEBUG ./app-record-replay -cp -d -o | grep "ARR "` to run app service 
run `curl -d @./test.json  localhost:59712/api/v3/data -H "Content-Type: application/json"`
Verify logs contain:
```
level=DEBUG ts=2023-08-28T22:58:29.269147886Z app=app-record-replay source=controller.go:320 msg="ARR Import - Importing as JSON w/o compression"    
level=DEBUG ts=2023-08-28T22:58:29.272133214Z app=app-record-replay source=manager.go:624 msg="ARR Import: Existing device profile Random-Integer-Device not updated: Can not update existing device profiles"
level=DEBUG ts=2023-08-28T22:58:29.273312025Z app=app-record-replay source=manager.go:624 msg="ARR Import: Existing device profile Random-UnsignedInteger-Device not updated: Can not update existing device profiles"
level=DEBUG ts=2023-08-28T22:58:29.274273234Z app=app-record-replay source=manager.go:624 msg="ARR Import: Existing device profile Random-Boolean-Device not updated: Can not update existing device profiles"
level=DEBUG ts=2023-08-28T22:58:29.278831577Z app=app-record-replay source=manager.go:591 msg="ARR Import: Updated existing device Random-UnsignedInteger-Device"
level=DEBUG ts=2023-08-28T22:58:29.284153527Z app=app-record-replay source=manager.go:591 msg="ARR Import: Updated existing device Random-Boolean-Device"
level=DEBUG ts=2023-08-28T22:58:29.289430277Z app=app-record-replay source=manager.go:591 msg="ARR Import: Updated existing device Random-Integer-Device"
level=DEBUG ts=2023-08-28T22:58:29.289491077Z app=app-record-replay source=manager.go:543 msg="ARR Import: Imported 10 events, 3 devices and 3 device profiles"
```
From EdgeX UI remove all the Devices and then remove all the Device Profiles
run `curl -d @./test.json  localhost:59712/api/v3/data?overwire=false -H "Content-Type: application/json"`
Verify logs contain add messages for  Devices or Profiles:
```
level=DEBUG ts=2023-08-28T23:22:37.943454305Z app=app-record-replay source=controller.go:320 msg="ARR Import - Importing as JSON w/o compression"
level=DEBUG ts=2023-08-28T23:22:37.950126946Z app=app-record-replay source=manager.go:614 msg="ARR Import: Add new device profile Random-Integer-Device"
level=DEBUG ts=2023-08-28T23:22:37.953212966Z app=app-record-replay source=manager.go:614 msg="ARR Import: Add new device profile Random-UnsignedInteger-Device"
level=DEBUG ts=2023-08-28T23:22:37.955899182Z app=app-record-replay source=manager.go:614 msg="ARR Import: Add new device profile Random-Boolean-Device"
level=DEBUG ts=2023-08-28T23:22:37.960826412Z app=app-record-replay source=manager.go:563 msg="ARR Import: Added new device Random-UnsignedInteger-Device"
level=DEBUG ts=2023-08-28T23:22:37.96527644Z app=app-record-replay source=manager.go:563 msg="ARR Import: Added new device Random-Boolean-Device"
level=DEBUG ts=2023-08-28T23:22:37.969019363Z app=app-record-replay source=manager.go:563 msg="ARR Import: Added new device Random-Integer-Device"
level=DEBUG ts=2023-08-28T23:22:37.969071563Z app=app-record-replay source=manager.go:543 msg="ARR Import: Imported 10 events, 3 devices and 3 device profiles"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->