### PR TITLE
refactor: Adjust returns to use echo ctx.NoContent()

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -133,8 +133,7 @@ func (c *httpController) startRecording(ctx echo.Context) error {
 		return ctx.String(http.StatusInternalServerError, fmt.Sprintf("%s: %v", failedRecording, err))
 	}
 
-	ctx.Response().WriteHeader(http.StatusAccepted)
-	return nil
+	return ctx.NoContent(http.StatusAccepted)
 }
 
 // CancelRecording cancels the current recording session
@@ -180,8 +179,7 @@ func (c *httpController) startReplay(ctx echo.Context) error {
 		return ctx.String(http.StatusInternalServerError, fmt.Sprintf("%s: %v", failedReplay, err))
 	}
 
-	ctx.Response().WriteHeader(http.StatusAccepted)
-	return nil
+	return ctx.NoContent(http.StatusAccepted)
 }
 
 // cancelReplay cancels the current replay session as the HTTP response.
@@ -190,8 +188,7 @@ func (c *httpController) cancelReplay(ctx echo.Context) error {
 		return ctx.String(http.StatusInternalServerError, fmt.Sprintf("failed to cancel replay: %v", err))
 	}
 
-	ctx.Response().WriteHeader(http.StatusAccepted)
-	return nil
+	return ctx.NoContent(http.StatusAccepted)
 }
 
 // replayStatus returns the status of the current replay session as the HTTP response.
@@ -323,6 +320,5 @@ func (c *httpController) importRecordedData(ctx echo.Context) error {
 		return ctx.String(http.StatusInternalServerError, fmt.Sprintf("%s: %v", failedImportingData, err))
 	}
 
-	ctx.Response().WriteHeader(http.StatusAccepted)
-	return nil
+	return ctx.NoContent(http.StatusAccepted)
 }


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-record-replay/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. run edgex stack
2. build record and replay
3. run record and replay
4. use postman collection to test

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->